### PR TITLE
fix(read): introduce copychars to address memory issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1"
+  },
+  "dependencies": {
+    "@dcos/copychars": "^0.1.0"
   }
 }

--- a/src/read.js
+++ b/src/read.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var copychars = require("@dcos/copychars").default;
+
 var RECORD_PATTERN = /^\d+\n.+/;
 
 module.exports = function read(input) {
@@ -23,7 +25,7 @@ module.exports = function read(input) {
       return [records, rest];
     }
 
-    record = rest.substring(recordStartPosition, recordEndPosition);
+    record = copychars(rest, recordStartPosition, recordLength);
     rest = rest.substring(recordEndPosition);
 
     records.push(record);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@dcos/copychars@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@dcos/copychars/-/copychars-0.1.0.tgz#230bb4707323090b97874207424e260cba6c309f"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"


### PR DESCRIPTION
Use copychars instead to substring to ensure the string is copied
instead of _referenced_ to avoid optimization that are counterproductive when
parsing a large amount of data into records.