### PR TITLE
chore(deps): update dependency jest to v23 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "jest": "^21.2.1",
+    "jest": "^23.0.0",
     "jest-cli": "^21.2.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,31 @@
 # yarn lockfile v1
 
 
-"@dcos/copychars@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@dcos/copychars/-/copychars-0.1.0.tgz#230bb4707323090b97874207424e260cba6c309f"
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.55.tgz#71f530e7b010af5eb7a7df7752f78921dd57e9ee"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.55"
 
-abab@^1.0.3:
+"@babel/highlight@7.0.0-beta.55":
+  version "7.0.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.55.tgz#988653647d629c261dae156e74d5f0252ba520c0"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@dcos/copychars@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@dcos/copychars/-/copychars-0.1.2.tgz#c29c759fe6ed140689324b527cb4d6fbab71090b"
+
+abab@^1.0.3, abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
+
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
 
 abbrev@1:
   version "1.1.1"
@@ -20,9 +38,19 @@ acorn-globals@^3.1.0:
   dependencies:
     acorn "^4.0.4"
 
+acorn-globals@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
+  dependencies:
+    acorn "^5.0.0"
+
 acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.0.0, acorn@^5.5.3:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -74,6 +102,12 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -86,6 +120,12 @@ append-transform@^0.4.0:
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
   dependencies:
     default-require-extensions "^1.0.0"
+
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  dependencies:
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -110,9 +150,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -121,6 +169,10 @@ array-equal@^1.0.0:
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -138,9 +190,17 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@^1.4.0:
   version "1.5.2"
@@ -155,6 +215,10 @@ async@^2.1.4:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -227,6 +291,13 @@ babel-jest@^21.2.0:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
 
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -241,9 +312,22 @@ babel-plugin-istanbul@^4.0.0:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
+babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
@@ -254,6 +338,13 @@ babel-preset-jest@^21.2.0:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
   dependencies:
     babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -285,7 +376,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -299,7 +390,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -315,6 +406,18 @@ babylon@^6.18.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -361,9 +464,34 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+browser-process-hrtime@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+
 browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -373,9 +501,27 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -410,6 +556,14 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
@@ -421,6 +575,15 @@ chalk@^2.0.1:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -438,6 +601,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -445,6 +616,13 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
 color-convert@^1.9.0:
   version "1.9.0"
@@ -462,6 +640,14 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+compare-versions@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
+
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -477,6 +663,10 @@ content-type-parser@^1.0.1:
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
@@ -516,13 +706,27 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+cssstyle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.0.0.tgz#79b16d51ec5591faec60e688891f15d2a5705129"
+  dependencies:
+    cssom "0.3.x"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
 
-debug@^2.2.0, debug@^2.6.8:
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
+
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -538,6 +742,10 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -551,6 +759,38 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  dependencies:
+    strip-bom "^3.0.0"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -566,9 +806,19 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -588,6 +838,24 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.5.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -602,6 +870,17 @@ escodegen@^1.6.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.5.6"
+
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -637,11 +916,27 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
   dependencies:
     is-posix-bracket "^0.1.0"
+
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 expand-range@^1.8.1:
   version "1.8.2"
@@ -660,6 +955,30 @@ expect@^21.2.1:
     jest-message-util "^21.2.1"
     jest-regex-util "^21.2.0"
 
+expect@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.4.0.tgz#6da4ecc99c1471253e7288338983ad1ebadb60c3"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.2.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -670,6 +989,19 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -677,6 +1009,10 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -709,6 +1045,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -722,7 +1067,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -731,6 +1076,10 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -751,6 +1100,12 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -780,6 +1135,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -800,6 +1159,10 @@ get-caller-file@^1.0.1:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -889,9 +1252,46 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -930,7 +1330,7 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-html-encoding-sniffer@^1.0.1:
+html-encoding-sniffer@^1.0.1, html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
@@ -955,6 +1355,17 @@ http-signature@~1.2.0:
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+
+iconv-lite@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -985,6 +1396,18 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -999,11 +1422,47 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
 is-ci@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1015,9 +1474,15 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -1039,6 +1504,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-generator-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -1057,6 +1526,12 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1065,9 +1540,19 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1076,6 +1561,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1090,6 +1579,10 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1111,15 +1604,54 @@ istanbul-api@^1.1.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
+istanbul-api@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
+  dependencies:
+    async "^2.1.4"
+    compare-versions "^3.1.0"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-report "^1.1.4"
+    istanbul-lib-source-maps "^1.2.4"
+    istanbul-reports "^1.3.0"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
 istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+
+istanbul-lib-coverage@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
   dependencies:
     append-transform "^0.4.0"
+
+istanbul-lib-hook@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
+  dependencies:
+    append-transform "^1.0.0"
+
+istanbul-lib-instrument@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.2.0"
+    semver "^5.3.0"
 
 istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.9.1:
   version "1.9.1"
@@ -1142,6 +1674,15 @@ istanbul-lib-report@^1.1.2:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
+istanbul-lib-report@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
+  dependencies:
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
 istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
@@ -1152,15 +1693,37 @@ istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.2:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
+istanbul-lib-source-maps@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
 istanbul-reports@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
 
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
+  dependencies:
+    handlebars "^4.0.3"
+
 jest-changed-files@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
+  dependencies:
+    throat "^4.0.0"
+
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
   dependencies:
     throat "^4.0.0"
 
@@ -1198,6 +1761,47 @@ jest-cli@^21.2.1:
     worker-farm "^1.3.1"
     yargs "^9.0.0"
 
+jest-cli@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.4.2.tgz#49d56bcfe6cf01871bfcc4a0494e08edaf2b61d0"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.4.2"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.4.2"
+    jest-runner "^23.4.2"
+    jest-runtime "^23.4.2"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^11.0.0"
+
 jest-config@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
@@ -1214,6 +1818,24 @@ jest-config@^21.2.1:
     jest-validate "^21.2.1"
     pretty-format "^21.2.1"
 
+jest-config@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.4.2.tgz#62a105e14b8266458f2bf4d32403b2c44418fa77"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.4.2"
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.4.2"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    pretty-format "^23.2.0"
+
 jest-diff@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
@@ -1223,9 +1845,31 @@ jest-diff@^21.2.1:
     jest-get-type "^21.2.0"
     pretty-format "^21.2.1"
 
+jest-diff@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.2.0.tgz#9f2cf4b51e12c791550200abc16b47130af1062a"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
+
 jest-docblock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
+  dependencies:
+    detect-newline "^2.1.0"
+
+jest-each@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.4.0.tgz#2fa9edd89daa1a4edc9ff9bf6062a36b71345143"
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.2.0"
 
 jest-environment-jsdom@^21.2.1:
   version "21.2.1"
@@ -1235,6 +1879,14 @@ jest-environment-jsdom@^21.2.1:
     jest-util "^21.2.1"
     jsdom "^9.12.0"
 
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
+
 jest-environment-node@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
@@ -1242,9 +1894,20 @@ jest-environment-node@^21.2.1:
     jest-mock "^21.2.0"
     jest-util "^21.2.1"
 
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+
 jest-get-type@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-get-type@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
 jest-haste-map@^21.2.0:
   version "21.2.0"
@@ -1256,6 +1919,18 @@ jest-haste-map@^21.2.0:
     micromatch "^2.3.11"
     sane "^2.0.0"
     worker-farm "^1.3.1"
+
+jest-haste-map@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.4.1.tgz#43a174ba7ac079ae1dd74eaf5a5fe78989474dd2"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
 
 jest-jasmine2@^21.2.1:
   version "21.2.1"
@@ -1270,6 +1945,29 @@ jest-jasmine2@^21.2.1:
     jest-snapshot "^21.2.1"
     p-cancelable "^0.3.0"
 
+jest-jasmine2@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz#2fbf52f93e43ed4c5e7326a90bb1d785be4321ac"
+  dependencies:
+    babel-traverse "^6.0.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.4.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.2.0"
+    jest-each "^23.4.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    pretty-format "^23.2.0"
+
+jest-leak-detector@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz#c289d961dc638f14357d4ef96e0431ecc1aa377d"
+  dependencies:
+    pretty-format "^23.2.0"
+
 jest-matcher-utils@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
@@ -1277,6 +1975,14 @@ jest-matcher-utils@^21.2.1:
     chalk "^2.0.1"
     jest-get-type "^21.2.0"
     pretty-format "^21.2.1"
+
+jest-matcher-utils@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz#4d4981f23213e939e3cedf23dc34c747b5ae1913"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
 
 jest-message-util@^21.2.1:
   version "21.2.1"
@@ -1286,19 +1992,44 @@ jest-message-util@^21.2.1:
     micromatch "^2.3.11"
     slash "^1.0.0"
 
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
 
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
+
 jest-regex-util@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
+
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
 
 jest-resolve-dependencies@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
   dependencies:
     jest-regex-util "^21.2.0"
+
+jest-resolve-dependencies@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz#0675ba876a5b819deffc449ad72e9985c2592048"
+  dependencies:
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.4.2"
 
 jest-resolve@^21.2.0:
   version "21.2.0"
@@ -1307,6 +2038,14 @@ jest-resolve@^21.2.0:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     is-builtin-module "^1.0.0"
+
+jest-resolve@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.4.1.tgz#7f3c17104732a2c0c940a01256025ed745814982"
+  dependencies:
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
 
 jest-runner@^21.2.1:
   version "21.2.1"
@@ -1322,6 +2061,24 @@ jest-runner@^21.2.1:
     pify "^3.0.0"
     throat "^4.0.0"
     worker-farm "^1.3.1"
+
+jest-runner@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.4.2.tgz#579a88524ac52c846075b0129a21c7b483e75a7e"
+  dependencies:
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.2"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.4.1"
+    jest-jasmine2 "^23.4.2"
+    jest-leak-detector "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.4.2"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
 
 jest-runtime@^21.2.1:
   version "21.2.1"
@@ -1345,6 +2102,36 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
+jest-runtime@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.4.2.tgz#00c3bb8385253d401a394a27d1112d3615e5a65c"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.2"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^11.0.0"
+
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
+
 jest-snapshot@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
@@ -1355,6 +2142,21 @@ jest-snapshot@^21.2.1:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     pretty-format "^21.2.1"
+
+jest-snapshot@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.4.2.tgz#8fa6130feb5a527dac73e5fa80d86f29f7c42ab6"
+  dependencies:
+    babel-types "^6.0.0"
+    chalk "^2.0.1"
+    jest-diff "^23.2.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.4.1"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.2.0"
+    semver "^5.5.0"
 
 jest-util@^21.2.1:
   version "21.2.1"
@@ -1368,6 +2170,19 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
+    mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
+
 jest-validate@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
@@ -1377,11 +2192,35 @@ jest-validate@^21.2.1:
     leven "^2.1.0"
     pretty-format "^21.2.1"
 
-jest@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
+jest-validate@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.4.0.tgz#d96eede01ef03ac909c009e9c8e455197d48c201"
   dependencies:
-    jest-cli "^21.2.1"
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.2.0"
+
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.0.0:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.4.2.tgz#1fae3ed832192143070ae85156b25cea891a1260"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.4.2"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -1397,6 +2236,37 @@ js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdom@^11.5.1:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  dependencies:
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
+    array-equal "^1.0.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
 
 jsdom@^9.12.0:
   version "9.12.0"
@@ -1461,7 +2331,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -1473,6 +2343,18 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+kleur@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -1482,6 +2364,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+left-pad@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -1520,6 +2406,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
+lodash@^4.13.1:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -1547,11 +2441,27 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -1574,6 +2484,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     object.omit "^2.0.0"
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
+
+micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
 
 mime-db@~1.30.0:
   version "1.30.0"
@@ -1603,6 +2531,13 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -1616,6 +2551,22 @@ ms@2.0.0:
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1633,6 +2584,15 @@ node-notifier@^5.0.2:
     semver "^5.3.0"
     shellwords "^0.1.0"
     which "^1.2.12"
+
+node-notifier@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
 
 node-pre-gyp@^0.6.36:
   version "0.6.38"
@@ -1694,6 +2654,10 @@ number-is-nan@^1.0.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
+nwsapi@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.7.tgz#6fc54c254621f10cac5225b76e81c74120139b78"
+
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -1702,12 +2666,43 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-keys@^1.0.8:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -1789,9 +2784,17 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -1855,6 +2858,20 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -1870,6 +2887,13 @@ pretty-format@^21.2.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -1877,6 +2901,17 @@ private@^0.1.7:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+prompts@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.13.tgz#7fad7ee1c6cafe49834ca0b2a6a471262de57620"
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -1886,9 +2921,17 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@~6.4.0:
   version "6.4.0"
@@ -1944,6 +2987,18 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+readable-stream@^2.0.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -1956,6 +3011,12 @@ readable-stream@^2.0.6, readable-stream@^2.1.4:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+realpath-native@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
+  dependencies:
+    util.promisify "^1.0.0"
+
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
@@ -1966,6 +3027,13 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -1974,7 +3042,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -1983,6 +3051,20 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
 
 request@2.81.0:
   version "2.81.0"
@@ -2038,6 +3120,31 @@ request@^2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
+request@^2.87.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -2046,9 +3153,27 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  dependencies:
+    resolve-from "^3.0.0"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -2056,7 +3181,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -2065,6 +3190,12 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 sane@^2.0.0:
   version "2.2.0"
@@ -2080,7 +3211,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@^1.2.1:
+sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -2088,9 +3219,31 @@ sax@^1.2.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.4.1, semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -2102,7 +3255,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shellwords@^0.1.0:
+shellwords@^0.1.0, shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
@@ -2110,9 +3263,40 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -2126,11 +3310,32 @@ sntp@2.x.x:
   dependencies:
     hoek "4.x.x"
 
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -2141,6 +3346,10 @@ source-map@^0.4.4:
 source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -2155,6 +3364,12 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2174,6 +3389,21 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -2189,7 +3419,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -2199,6 +3429,12 @@ string-width@^2.0.0:
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -2252,7 +3488,13 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-symbol-tree@^3.2.1:
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+symbol-tree@^3.2.1, symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -2287,6 +3529,16 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+test-exclude@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -2299,11 +3551,46 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -2346,9 +3633,40 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
 
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
@@ -2369,6 +3687,12 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -2386,7 +3710,7 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -2396,12 +3720,30 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
+whatwg-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
+  dependencies:
+    iconv-lite "0.4.19"
+
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+
 whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -2410,6 +3752,12 @@ which-module@^2.0.0:
 which@^1.2.12, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 
@@ -2461,9 +3809,19 @@ write-file-atomic@^2.1.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 xtend@^4.0.1:
   version "4.0.1"
@@ -2482,6 +3840,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/facebook/jest">jest</a> from <code>^21.2.1</code> to <code>^23.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2342httpsgithubcomfacebookjestblobmasterchangelogmd82032342"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2342"><code>v23.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/8b8f5bc40efc658c3dc8bc83de592293e245f37c…6ebdd3dd44ab71160fd2d3d78a4a37ef4d4d3c5a">Compare Source</a></p>
<h5 id="performance">Performance</h5>
<ul>
<li><code>[jest-changed-files]</code> limit git and hg commands to specified roots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6732">#&#8203;6732</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-circus]</code> Fix retryTimes so errors are reset before re-running (<a href="https://renovatebot.com/gh/facebook/jest/pull/6762">#&#8203;6762</a>)</li>
<li><code>[docs]</code> Update <code>expect.objectContaining()</code> description (<a href="https://renovatebot.com/gh/facebook/jest/pull/6754">#&#8203;6754</a>)</li>
<li><code>[babel-jest]</code> Make <code>getCacheKey()</code> take into account <code>createTransformer</code> options (<a href="https://renovatebot.com/gh/facebook/jest/pull/6699">#&#8203;6699</a>)</li>
<li><code>[jest-jasmine2]</code> Use prettier through <code>require</code> instead of <code>localRequire</code>. Fixes <code>matchInlineSnapshot</code> where prettier dependencies like <code>path</code> and <code>fs</code> are mocked with <code>jest.mock</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6776">#&#8203;6776</a>)</li>
<li><code>[docs]</code> Fix contributors link (<a href="https://renovatebot.com/gh/facebook/jest/pull/6711">#&#8203;6711</a>)</li>
<li><code>[website]</code> Fix website versions page to link to correct language (<a href="https://renovatebot.com/gh/facebook/jest/pull/6734">#&#8203;6734</a>)</li>
</ul>
<hr />
<h3 id="v2341httpsgithubcomfacebookjestblobmasterchangelogmd82032341"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2341"><code>v23.4.1</code></a></h3>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-cli]</code> Watch plugins now have access to a broader range of global configuration options in their <code>updateConfigAndRun</code> callbacks, so they can provide a wider set of extra features (<a href="https://renovatebot.com/gh/facebook/jest/pull/6473">#&#8203;6473</a>)</li>
<li><code>[jest-snapshot]</code> <code>babel-traverse</code> is now passed to <code>jest-snapshot</code> explicitly to avoid unnecessary requires in every test</li>
</ul>
<h5 id="fixes-1">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Optimize watchman crawler by using <code>glob</code> on initial query (<a href="https://renovatebot.com/gh/facebook/jest/pull/6689">#&#8203;6689</a>)</li>
</ul>
<hr />
<h3 id="v2340httpsgithubcomfacebookjestblobmasterchangelogmd82032340"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2340"><code>v23.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/d6db226c171cfcbfb2ad1220cf96df1ad25a4ae6…6e1ec16e30b9510b187568a09050ddc5433cad04">Compare Source</a></p>
<h5 id="features-1">Features</h5>
<ul>
<li><code>[jest-haste-map]</code> Add <code>computeDependencies</code> flag to avoid opening files if not needed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6667">#&#8203;6667</a>)</li>
<li><code>[jest-runtime]</code> Support <code>require.resolve.paths</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
<li><code>[jest-runtime]</code> Support <code>paths</code> option for <code>require.resolve</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
</ul>
<h5 id="fixes-2">Fixes</h5>
<ul>
<li><code>[jest-runner]</code> Force parallel runs for watch mode, to avoid TTY freeze (<a href="https://renovatebot.com/gh/facebook/jest/pull/6647">#&#8203;6647</a>)</li>
<li><code>[jest-cli]</code> properly reprint resolver errors in watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6407">#&#8203;6407</a>)</li>
<li><code>[jest-cli]</code> Write configuration to stdout when the option was explicitly passed to Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6447">#&#8203;6447</a>)</li>
<li><code>[jest-cli]</code> Fix regression on non-matching suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/6657">6657</a>)</li>
<li><code>[jest-runtime]</code> Roll back <code>micromatch</code> version to prevent regression when matching files (<a href="https://renovatebot.com/gh/facebook/jest/pull/6661">#&#8203;6661</a>)</li>
</ul>
<hr />
<h3 id="v2330httpsgithubcomfacebookjestblobmasterchangelogmd82032330"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2330"><code>v23.3.0</code></a></h3>
<h5 id="features-2">Features</h5>
<ul>
<li><code>[jest-cli]</code> Allow watch plugin to be configured (<a href="https://renovatebot.com/gh/facebook/jest/pull/6603">#&#8203;6603</a>)</li>
<li><code>[jest-snapshot]</code> Introduce <code>toMatchInlineSnapshot</code> and <code>toThrowErrorMatchingInlineSnapshot</code> matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6380">#&#8203;6380</a>)</li>
</ul>
<h5 id="fixes-3">Fixes</h5>
<ul>
<li><code>[jest-regex-util]</code> Improve handling already escaped path separators on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6523">#&#8203;6523</a>)</li>
<li><code>[jest-cli]</code> Fix <code>testNamePattern</code> value with interactive snapshots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6579">#&#8203;6579</a>)</li>
<li><code>[jest-cli]</code> Fix enter to interrupt watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6601">#&#8203;6601</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[website]</code> Switch domain to <a href="https://jestjs.io">https://jestjs.io</a> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6549">#&#8203;6549</a>)</li>
<li><code>[tests]</code> Improve stability of <code>yarn test</code> on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6534">#&#8203;6534</a>)</li>
<li><code>[*]</code> Transpile object shorthand into Node 4 compatible syntax (<a href="https://renovatebot.com/gh/facebook/jest/pull/6582">#&#8203;6582</a>)</li>
<li><code>[*]</code> Update all legacy links to jestjs.io (<a href="https://renovatebot.com/gh/facebook/jest/pull/6622">#&#8203;6622</a>)</li>
<li><code>[docs]</code> Add docs for 23.1, 23.2, and 23.3 (<a href="https://renovatebot.com/gh/facebook/jest/pull/6623">#&#8203;6623</a>)</li>
<li><code>[website]</code> Only test/deploy website if relevant files are changed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6626">#&#8203;6626</a>)</li>
<li><code>[docs]</code> Describe behavior of <code>resetModules</code> option when set to <code>false</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6641">#&#8203;6641</a>)</li>
</ul>
<hr />
<h3 id="v2320httpsgithubcomfacebookjestblobmasterchangelogmd82032320"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2320"><code>v23.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/644dd0d6335651794e2f34ec73e7c82c0bc050d2…5010a5c5fb85cd8be62a583e57abace70d655ed4">Compare Source</a></p>
<h5 id="features-3">Features</h5>
<ul>
<li><code>[jest-each]</code> Add support for keyPaths in test titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6457">#&#8203;6457</a>)</li>
<li><code>[jest-cli]</code> Add <code>jest --init</code> option that generates a basic configuration file with a short description for each option (<a href="https://renovatebot.com/gh/facebook/jest/pull/6442">#&#8203;6442</a>)</li>
<li><code>[jest.retryTimes]</code> Add <code>jest.retryTimes()</code> option that allows failed tests to be retried n-times when using jest-circus. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6498">#&#8203;6498</a>)</li>
</ul>
<h5 id="fixes-4">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add check to make sure one or more tests have run before notifying when using <code>--notify</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6495">#&#8203;6495</a>)</li>
<li><code>[jest-cli]</code> Pass <code>globalConfig</code> as a parameter to <code>globalSetup</code> and <code>globalTeardown</code> functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/6486">#&#8203;6486</a>)</li>
<li><code>[jest-config]</code> Add missing options to the <code>defaults</code> object (<a href="https://renovatebot.com/gh/facebook/jest/pull/6428">#&#8203;6428</a>)</li>
<li><code>[expect]</code> Using symbolic property names in arrays no longer causes the <code>toEqual</code> matcher to fail (<a href="https://renovatebot.com/gh/facebook/jest/pull/6391">#&#8203;6391</a>)</li>
<li><code>[expect]</code> <code>toEqual</code> no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6398">#&#8203;6398</a>)</li>
<li><code>[jest-util]</code> <code>console.timeEnd</code> now properly log elapsed time in milliseconds. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6456">#&#8203;6456</a>)</li>
<li><code>[jest-mock]</code> Fix <code>MockNativeMethods</code> access in react-native <code>jest.mock()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6505">#&#8203;6505</a>)</li>
</ul>
<h5 id="chore--maintenance-1">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add jest-each docs for 1 dimensional arrays (<a href="https://renovatebot.com/gh/facebook/jest/pull/6444/files">#&#8203;6444</a>)</li>
</ul>
<hr />
<h3 id="v2310httpsgithubcomfacebookjestblobmasterchangelogmd82032310"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2310"><code>v23.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/3a3b4e3fdbcf9b9f33921cc452c5197a28d61d32…644dd0d6335651794e2f34ec73e7c82c0bc050d2">Compare Source</a></p>
<h5 id="features-4">Features</h5>
<ul>
<li><code>[jest-each]</code> Add pretty-format serialising to each titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6357">#&#8203;6357</a>)</li>
<li><code>[jest-cli]</code> shouldRunTestSuite watch hook now receives an object with <code>config</code>, <code>testPath</code> and <code>duration</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6350">#&#8203;6350</a>)</li>
<li><code>[jest-each]</code> Support one dimensional array of data (<a href="https://renovatebot.com/gh/facebook/jest/pull/6351">#&#8203;6351</a>)</li>
<li><code>[jest-watch]</code> create new package <code>jest-watch</code> to ease custom watch plugin development (<a href="https://renovatebot.com/gh/facebook/jest/pull/6318">#&#8203;6318</a>)</li>
<li><code>[jest-circus]</code> Make hooks in empty describe blocks error (<a href="https://renovatebot.com/gh/facebook/jest/pull/6320">#&#8203;6320</a>)</li>
<li>Add a config/CLI option <code>errorOnDeprecated</code> which makes calling deprecated APIs throw hepful error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6339">#&#8203;6339</a>)</li>
</ul>
<h5 id="fixes-5">Fixes</h5>
<ul>
<li><code>[jest-each]</code> Fix pluralising missing arguments error (<a href="https://renovatebot.com/gh/facebook/jest/pull/6369">#&#8203;6369</a>)</li>
<li><code>[jest-each]</code> Stop test title concatenating extra args (<a href="https://renovatebot.com/gh/facebook/jest/pull/6346">#&#8203;6346</a>)</li>
<li><code>[expect]</code> toHaveBeenNthCalledWith/nthCalledWith gives wrong call messages if not matched (<a href="https://renovatebot.com/gh/facebook/jest/pull/6340">#&#8203;6340</a>)</li>
<li><code>[jest-each]</code> Make sure invalid arguments to <code>each</code> points back to the user's code (<a href="https://renovatebot.com/gh/facebook/jest/pull/6347">#&#8203;6347</a>)</li>
<li><code>[expect]</code> toMatchObject throws TypeError when a source property is null (<a href="https://renovatebot.com/gh/facebook/jest/pull/6313">#&#8203;6313</a>)</li>
<li><code>[jest-cli]</code> Normalize slashes in paths in CLI output on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6310">#&#8203;6310</a>)</li>
<li><code>[jest-cli]</code> Fix run beforeAll in excluded suites tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6234">#&#8203;6234</a>)</li>
<li><code>[jest-haste-map</code>] Compute SHA-1s for non-tracked files when using Node crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/6264">#&#8203;6264</a>)</li>
</ul>
<h5 id="chore--maintenance-2">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Improve documentation of <code>mockClear</code>, <code>mockReset</code>, and <code>mockRestore</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6227/files">#&#8203;6227</a>)</li>
<li><code>[jest-circus]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/#&#8203;6309">#&#8203;6309</a>)</li>
<li><code>[jest-each]</code> Refactor each to use shared implementation with core (<a href="https://renovatebot.com/gh/facebook/jest/pull/6345">#&#8203;6345</a>)</li>
<li><code>[jest-each]</code> Update jest-each docs for serialising values into titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6337">#&#8203;6337</a>)</li>
<li><code>[jest-circus]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6309">#&#8203;6309</a>)</li>
<li><code>[filenames]</code> Rename "integration-tests" to "e2e" (<a href="https://renovatebot.com/gh/facebook/jest/pull/6315">#&#8203;6315</a>)</li>
<li><code>[docs]</code> Mention the use of commit hash with <code>--changedSince</code> flag (<a href="https://renovatebot.com/gh/facebook/jest/pull/6330">#&#8203;6330</a>)</li>
</ul>
<hr />
<h3 id="v2301httpsgithubcomfacebookjestblobmasterchangelogmd82032301"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2301"><code>v23.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/614f739378d4f1757d8dc99219309553db5b9403…3a3b4e3fdbcf9b9f33921cc452c5197a28d61d32">Compare Source</a></p>
<h5 id="chore--maintenance-3">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-jasemine2]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6308">#&#8203;6308</a>)</li>
<li><code>[jest-each]</code> Move jest-each into core Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6278">#&#8203;6278</a>)</li>
<li><code>[examples]</code> Update typescript example to using ts-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6260">#&#8203;6260</a>)</li>
</ul>
<h5 id="fixes-6">Fixes</h5>
<ul>
<li><code>[pretty-format]</code> Serialize inverse asymmetric matchers correctly (<a href="https://renovatebot.com/gh/facebook/jest/pull/6272">#&#8203;6272</a>)</li>
</ul>
<hr />
<h3 id="v2300httpsgithubcomfacebookjestblobmasterchangelogmd82032300"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2300"><code>v23.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/f4f51914d577dc53748f599f3f626dfe3154883e…614f739378d4f1757d8dc99219309553db5b9403">Compare Source</a></p>
<h5 id="features-5">Features</h5>
<ul>
<li><code>[expect]</code> Expose <code>getObjectSubset</code>, <code>iterableEquality</code>, and <code>subsetEquality</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-snapshot]</code> Add snapshot property matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-config]</code> Support jest-preset.js files within Node modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/6185">#&#8203;6185</a>)</li>
<li><code>[jest-cli]</code> Add <code>--detectOpenHandles</code> flag which enables Jest to potentially track down handles keeping it open after tests are complete. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6130">#&#8203;6130</a>)</li>
<li><code>[jest-jasmine2]</code> Add data driven testing based on <code>jest-each</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6102">#&#8203;6102</a>)</li>
<li><code>[jest-matcher-utils]</code> Change "suggest to equal" message to be more advisory (<a href="https://renovatebot.com/gh/facebook/jest/issues/6103">#&#8203;6103</a>)</li>
<li><code>[jest-message-util]</code> Don't ignore messages with <code>vendor</code> anymore (<a href="https://renovatebot.com/gh/facebook/jest/pull/6117">#&#8203;6117</a>)</li>
<li><code>[jest-validate]</code> Get rid of <code>jest-config</code> dependency (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-validate]</code> Adds option to inject <code>deprecationEntries</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test, optional snapshot name and count (<a href="https://renovatebot.com/gh/facebook/jest/pull/6015">#&#8203;6015</a>)</li>
<li><code>[jest-runtime]</code> Allow for transform plugins to skip the definition process method if createTransformer method was defined. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5999">#&#8203;5999</a>)</li>
<li><code>[expect]</code> Add stack trace for async errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for timeouts (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for thrown non-<code>Error</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-runtime]</code> Prevent modules from marking themselves as their own parent (<a href="https://renovatebot.com/gh/facebook/jest/issues/5235">#&#8203;5235</a>)</li>
<li><code>[jest-mock]</code> Add support for auto-mocking generator functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5983">#&#8203;5983</a>)</li>
<li><code>[expect]</code> Add support for async matchers  (<a href="https://renovatebot.com/gh/facebook/jest/pull/5919">#&#8203;5919</a>)</li>
<li><code>[expect]</code> Suggest toContainEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/5953">#&#8203;5948</a>)</li>
<li><code>[jest-config]</code> Export Jest's default options (<a href="https://renovatebot.com/gh/facebook/jest/pull/5948">#&#8203;5948</a>)</li>
<li><code>[jest-editor-support]</code> Move <code>coverage</code> to <code>ProjectWorkspace.collectCoverage</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5929">#&#8203;5929</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>coverage</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5836">#&#8203;5836</a>)</li>
<li><code>[jest-haste-map]</code> Support extracting dynamic <code>import</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/5883">#&#8203;5883</a>)</li>
<li><code>[expect]</code> Improve output format for mismatchedArgs in mock/spy calls. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5846">#&#8203;5846</a>)</li>
<li><code>[jest-cli]</code> Add support for using <code>--coverage</code> in combination with watch mode, <code>--onlyChanged</code>, <code>--findRelatedTests</code> and more (<a href="https://renovatebot.com/gh/facebook/jest/pull/5601">#&#8203;5601</a>)</li>
<li><code>[jest-jasmine2]</code> [<strong>BREAKING</strong>] Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments. <code>[jest-circus]</code> Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5558">#&#8203;5558</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>isNot</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5512">#&#8203;5512</a>)</li>
<li><code>[jest-config]</code> Add <code>&lt;rootDir&gt;</code> to runtime files not found error report (<a href="https://renovatebot.com/gh/facebook/jest/pull/5693">#&#8203;5693</a>)</li>
<li><code>[expect]</code> Make toThrow matcher pass only if Error object is returned from promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add isError to utils (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add inverse matchers (<code>expect.not.arrayContaining</code>, etc., <a href="https://renovatebot.com/gh/facebook/jest/pull/5517">#&#8203;5517</a>)</li>
<li><code>[expect]</code> <code>expect.extend</code> now also extends asymmetric matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5503">#&#8203;5503</a>)</li>
<li><code>[jest-mock]</code> Update <code>spyOnProperty</code> to support spying on the prototype chain (<a href="https://renovatebot.com/gh/facebook/jest/pull/5753">#&#8203;5753</a>)</li>
<li><code>[jest-mock]</code> Add tracking of return values in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5752">#&#8203;5752</a>)</li>
<li><code>[jest-mock]</code> Add tracking of thrown errors in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5764">#&#8203;5764</a>)</li>
<li><code>[expect]</code>Add nthCalledWith spy matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5605">#&#8203;5605</a>)</li>
<li><code>[jest-cli]</code> Add <code>isSerial</code> property that runners can expose to specify that they can not run in parallel (<a href="https://renovatebot.com/gh/facebook/jest/pull/5706">#&#8203;5706</a>)</li>
<li><code>[expect]</code> Add <code>.toBeCalledTimes</code> and <code>toHaveBeenNthCalledWith</code> aliases (<a href="https://renovatebot.com/gh/facebook/jest/pull/5826">#&#8203;5826</a>)</li>
<li><code>[jest-cli]</code> Interactive Snapshot Mode improvements (<a href="https://renovatebot.com/gh/facebook/jest/pull/5864">#&#8203;5864</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>no-color</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5909">#&#8203;5909</a>)</li>
<li><code>[jest-jasmine2]</code> Pretty-print non-Error object errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5980">#&#8203;5980</a>)</li>
<li><code>[jest-message-util]</code> Include column in stack frames (<a href="https://renovatebot.com/gh/facebook/jest/pull/5889">#&#8203;5889</a>)</li>
<li><code>[expect]</code> Introduce toStrictEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/6032">#&#8203;6032</a>)</li>
<li><code>[expect]</code> Add return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5879">#&#8203;5879</a>)</li>
<li><code>[jest-cli]</code> Improve snapshot summaries (<a href="https://renovatebot.com/gh/facebook/jest/pull/6181">#&#8203;6181</a>)</li>
<li><code>[expect]</code> Include custom mock names in error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6199">#&#8203;6199</a>)</li>
<li><code>[jest-diff]</code> Support returning diff from oneline strings (<a href="https://renovatebot.com/gh/facebook/jest/pull/6221">#&#8203;6221</a>)</li>
<li><code>[expect]</code> Improve return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6172">#&#8203;6172</a>)</li>
<li><code>[jest-cli]</code> Overhaul watch plugin hooks names (<a href="https://renovatebot.com/gh/facebook/jest/pull/6249">#&#8203;6249</a>)</li>
<li><code>[jest-mock]</code> Include tracked call results in serialized mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/6244">#&#8203;6244</a>)</li>
</ul>
<h5 id="fixes-7">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Fix stdin encoding to utf8 for watch plugins. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6253">#&#8203;6253</a>)</li>
<li><code>[expect]</code> Better detection of DOM Nodes for equality (<a href="https://renovatebot.com/gh/facebook/jest/pull/6246">#&#8203;6246</a>)</li>
<li><code>[jest-cli]</code> Fix misleading action description for F key when in "only failed tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6167">#&#8203;6167</a>)</li>
<li><code>[jest-worker]</code> Stick calls to workers before processing them (<a href="https://renovatebot.com/gh/facebook/jest/pull/6073">#&#8203;6073</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Allow using <code>console</code> global variable (<a href="https://renovatebot.com/gh/facebook/jest/pull/6075">#&#8203;6075</a>)</li>
<li><code>[jest-jasmine2]</code> Always remove node core message from assert stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6055">#&#8203;6055</a>)</li>
<li><code>[expect]</code> Add stack trace when <code>expect.assertions</code> and <code>expect.hasAssertions</code> causes test failures. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5997">#&#8203;5997</a>)</li>
<li><code>[jest-runtime]</code> Throw a more useful error when trying to require modules after the test environment is torn down (<a href="https://renovatebot.com/gh/facebook/jest/pull/5888">#&#8203;5888</a>)</li>
<li><code>[jest-mock]</code> [<strong>BREAKING</strong>] Replace timestamps with <code>invocationCallOrder</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5867">#&#8203;5867</a>)</li>
<li><code>[jest-jasmine2]</code> Install <code>sourcemap-support</code> into normal runtime to catch runtime errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5945">#&#8203;5945</a>)</li>
<li><code>[jest-jasmine2]</code> Added assertion error handling inside <code>afterAll hook</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5884">#&#8203;5884</a>)</li>
<li><code>[jest-cli]</code> Remove the notifier actions in case of failure when not in watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5861">#&#8203;5861</a>)</li>
<li><code>[jest-mock]</code> Extend .toHaveBeenCalled return message with outcome (<a href="https://renovatebot.com/gh/facebook/jest/pull/5951">#&#8203;5951</a>)</li>
<li><code>[jest-runner]</code> Assign <code>process.env.JEST_WORKER_ID="1"</code> when in runInBand mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5860">#&#8203;5860</a>)</li>
<li><code>[jest-cli]</code> Add descriptive error message when trying to use <code>globalSetup</code>/<code>globalTeardown</code> file that doesn't export a function. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5835">#&#8203;5835</a>)</li>
<li><code>[expect]</code> Do not rely on <code>instanceof RegExp</code>, since it will not work for RegExps created inside of a different VM (<a href="https://renovatebot.com/gh/facebook/jest/pull/5729">#&#8203;5729</a>)</li>
<li><code>[jest-resolve]</code> Update node module resolution algorithm to correctly handle symlinked paths (<a href="https://renovatebot.com/gh/facebook/jest/pull/5085">#&#8203;5085</a>)</li>
<li><code>[jest-editor-support]</code> Update <code>Settings</code> to use spawn in shell option (<a href="https://renovatebot.com/gh/facebook/jest/pull/5658">#&#8203;5658</a>)</li>
<li><code>[jest-cli]</code> Improve the error message when 2 projects resolve to the same config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5674">#&#8203;5674</a>)</li>
<li><code>[jest-runtime]</code> remove retainLines from coverage instrumentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5692">#&#8203;5692</a>)</li>
<li><code>[jest-cli]</code> Fix update snapshot issue when using watchAll (<a href="https://renovatebot.com/gh/facebook/jest/pull/5696">#&#8203;5696</a>)</li>
<li><code>[expect]</code> Fix rejects.not matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[jest-runtime]</code> Prevent Babel warnings on large files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5702">#&#8203;5702</a>)</li>
<li><code>[jest-mock]</code> Prevent <code>mockRejectedValue</code> from causing unhandled rejection (<a href="https://renovatebot.com/gh/facebook/jest/pull/5720">#&#8203;5720</a>)</li>
<li><code>[pretty-format]</code> Handle React fragments better (<a href="https://renovatebot.com/gh/facebook/jest/pull/5816">#&#8203;5816</a>)</li>
<li><code>[pretty-format]</code> Handle formatting of <code>React.forwardRef</code> and <code>Context</code> components (<a href="https://renovatebot.com/gh/facebook/jest/pull/6093">#&#8203;6093</a>)</li>
<li><code>[jest-cli]</code> Switch collectCoverageFrom back to a string (<a href="https://renovatebot.com/gh/facebook/jest/pull/5914">#&#8203;5914</a>)</li>
<li><code>[jest-regex-util]</code> Fix handling regex symbols in tests path on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5941">#&#8203;5941</a>)</li>
<li><code>[jest-util]</code> Fix handling of NaN/Infinity in mock timer delay (<a href="https://renovatebot.com/gh/facebook/jest/pull/5966">#&#8203;5966</a>)</li>
<li><code>[jest-resolve]</code> Generalise test for package main entries equivalent to ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5968">#&#8203;5968</a>)</li>
<li><code>[jest-config]</code> Ensure that custom resolvers are used when resolving the configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5976">#&#8203;5976</a>)</li>
<li><code>[website]</code> Fix website docs (<a href="https://renovatebot.com/gh/facebook/jest/pull/5853">#&#8203;5853</a>)</li>
<li><code>[expect]</code> Fix isEqual Set and Map to compare object values and keys regardless of order (<a href="https://renovatebot.com/gh/facebook/jest/pull/6150">#&#8203;6150</a>)</li>
<li><code>[pretty-format]</code> [<strong>BREAKING</strong>] Remove undefined props from React elements (<a href="https://renovatebot.com/gh/facebook/jest/pull/6162">#&#8203;6162</a>)</li>
<li><code>[jest-haste-map]</code> Properly resolve mocked node modules without package.json defined (<a href="https://renovatebot.com/gh/facebook/jest/pull/6232">#&#8203;6232</a>)</li>
</ul>
<h5 id="chore--maintenance-4">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-runner]</code> Move sourcemap installation from <code>jest-jasmine2</code> to <code>jest-runner</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6176">#&#8203;6176</a>)</li>
<li><code>[jest-cli]</code> Use yargs's built-in <code>version</code> instead of rolling our own (<a href="https://renovatebot.com/gh/facebook/jest/pull/6215">#&#8203;6215</a>)</li>
<li><code>[docs]</code> Add explanation on how to mock methods not implemented in JSDOM</li>
<li><code>[jest-jasmine2]</code> Simplify <code>Env.execute</code> and TreeProcessor to setup and clean resources for the top suite the same way as for all of the children suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/5885">#&#8203;5885</a>)</li>
<li><code>[babel-jest]</code> [<strong>BREAKING</strong>] Always return object from transformer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5991">#&#8203;5991</a>)</li>
<li><code>[*]</code> Run Prettier on compiled output (<a href="https://renovatebot.com/gh/facebook/jest/pull/3497">#&#8203;5858</a>)</li>
<li><code>[jest-cli]</code> Add fileChange hook for plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5708">#&#8203;5708</a>)</li>
<li><code>[docs]</code> Add docs on using <code>jest.mock(...)</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5648">#&#8203;5648</a>)</li>
<li><code>[docs]</code> Mention Jest Puppeteer Preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5722">#&#8203;5722</a>)</li>
<li><code>[docs]</code> Add jest-community section to website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5675">#&#8203;5675</a>)</li>
<li><code>[docs]</code> Add versioned docs for v22.4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5733">#&#8203;5733</a>)</li>
<li><code>[docs]</code> Improve Snapshot Testing Guide (<a href="https://renovatebot.com/gh/facebook/jest/issues/5812">#&#8203;5812</a>)</li>
<li><code>[jest-runtime]</code> [<strong>BREAKING</strong>] Remove <code>jest.genMockFn</code> and <code>jest.genMockFunction</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6173">#&#8203;6173</a>)</li>
<li><code>[jest-message-util]</code> Avoid adding unnecessary indent to blank lines in stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6211">#&#8203;6211</a>)</li>
</ul>
<hr />
<h3 id="v2244httpsgithubcomfacebookjestcompare6851d8bc9d67e83fb1bb0199d28ef84565938225f4f51914d577dc53748f599f3f626dfe3154883e"><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…f4f51914d577dc53748f599f3f626dfe3154883e"><code>v22.4.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…f4f51914d577dc53748f599f3f626dfe3154883e">Compare Source</a></p>
<hr />
<h3 id="v2242httpsgithubcomfacebookjestblobmasterchangelogmd82032242"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2242"><code>v22.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/f020182451e934221dedd92d2f550c55126f0985…cdd5dfea815bd043703c991dcca2051458d7ee75">Compare Source</a></p>
<h5 id="fixes-8">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Recreate Haste map when deserialization fails (<a href="https://renovatebot.com/gh/facebook/jest/pull/5642">#&#8203;5642</a>)</li>
</ul>
<hr />
<h3 id="v2241httpsgithubcomfacebookjestblobmasterchangelogmd82032241"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2241"><code>v22.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/9df3035829299a93579bad8cfb1db2081617ea6e…f020182451e934221dedd92d2f550c55126f0985">Compare Source</a></p>
<h5 id="fixes-9">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Parallelize Watchman calls in crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/5640">#&#8203;5640</a>)</li>
<li><code>[jest-editor-support]</code> Update TypeScript definitions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5625">#&#8203;5625</a>)</li>
<li><code>[babel-jest]</code> Remove <code>retainLines</code> argument to babel. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5594">#&#8203;5594</a>)</li>
</ul>
<h5 id="features-6">Features</h5>
<ul>
<li><code>[jest-runtime]</code> Provide <code>require.main</code> property set to module with test suite (<a href="https://renovatebot.com/gh/facebook/jest/pull/5618">#&#8203;5618</a>)</li>
</ul>
<h5 id="chore--maintenance-5">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add note about Node version support (<a href="https://renovatebot.com/gh/facebook/jest/pull/5622">#&#8203;5622</a>)</li>
<li><code>[docs]</code> Update to use yarn (<a href="https://renovatebot.com/gh/facebook/jest/pull/5624">#&#8203;5624</a>)</li>
<li><code>[docs]</code> Add how to mock scoped modules to Manual Mocks doc (<a href="https://renovatebot.com/gh/facebook/jest/pull/5638">#&#8203;5638</a>)</li>
</ul>
<hr />
<h3 id="v2240httpsgithubcomfacebookjestblobmasterchangelogmd82032240"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2240"><code>v22.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/d9b4f0c78c56377ccdda1523217bb49bb0d5f2db…9df3035829299a93579bad8cfb1db2081617ea6e">Compare Source</a></p>
<h5 id="fixes-10">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Overhauls how Watchman crawler works fixing Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5615">#&#8203;5615</a>)</li>
<li><code>[expect]</code> Allow matching of Errors against plain objects (<a href="https://renovatebot.com/gh/facebook/jest/pull/5611">#&#8203;5611</a>)</li>
<li><code>[jest-haste-map]</code> Do not read binary files in Haste, even when instructed to do so (<a href="https://renovatebot.com/gh/facebook/jest/pull/5612">#&#8203;5612</a>)</li>
<li><code>[jest-cli]</code> Don't skip matchers for exact files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5582">#&#8203;5582</a>)</li>
<li><code>[docs]</code> Update discord links (<a href="https://renovatebot.com/gh/facebook/jest/pull/5586">#&#8203;5586</a>)</li>
<li><code>[jest-runtime]</code> Align handling of testRegex on Windows between searching for tests and instrumentation checks (<a href="https://renovatebot.com/gh/facebook/jest/pull/5560">#&#8203;5560</a>)</li>
<li><code>[jest-config]</code> Make it possible to merge <code>transform</code> option with preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5505">#&#8203;5505</a>)</li>
<li><code>[jest-util]</code> Fix <code>console.assert</code> behavior in custom &amp; buffered consoles (<a href="https://renovatebot.com/gh/facebook/jest/pull/5576">#&#8203;5576</a>)</li>
</ul>
<h5 id="features-7">Features</h5>
<ul>
<li><code>[docs]</code> Add MongoDB guide (<a href="https://renovatebot.com/gh/facebook/jest/pull/5571">#&#8203;5571</a>)</li>
<li><code>[jest-runtime]</code> Deprecate mapCoverage option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[babel-jest]</code> Add option to return sourcemap from the transformer separately from source. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[jest-validate]</code> Add ability to log deprecation warnings for CLI flags. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5536">#&#8203;5536</a>)</li>
<li><code>[jest-serializer]</code> Added new module for serializing. Works using V8 or JSON (<a href="https://renovatebot.com/gh/facebook/jest/pull/5609">#&#8203;5609</a>)</li>
<li><code>[docs]</code> Add a documentation note for project <code>displayName</code> configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5600">#&#8203;5600</a>)</li>
</ul>
<h5 id="chore--maintenance-6">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Update automatic mocks documentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5630">#&#8203;5630</a>)</li>
</ul>
<hr />
<h3 id="v2230httpsgithubcomfacebookjestblobmasterchangelogmdjest-2230"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2230"><code>v22.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/786f2956b863095313a8d727b1c85196542d1d1d…d9b4f0c78c56377ccdda1523217bb49bb0d5f2db">Compare Source</a></p>
<h5 id="fixes-11">Fixes</h5>
<ul>
<li><code>[expect]</code> Add descriptive error message to CalledWith methods when missing optional arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5547">#&#8203;5547</a>)</li>
<li><code>[jest-cli]</code> Fix inability to quit watch mode while debugger is still attached (<a href="https://renovatebot.com/gh/facebook/jest/pull/5029">#&#8203;5029</a>)</li>
<li><code>[jest-haste-map]</code> Properly handle platform-specific file deletions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5534">#&#8203;5534</a>)</li>
</ul>
<h5 id="features-8">Features</h5>
<ul>
<li><code>[jest-util]</code> Add the following methods to the "console" implementations: <code>assert</code>, <code>count</code>, <code>countReset</code>, <code>dir</code>, <code>dirxml</code>, <code>group</code>, <code>groupCollapsed</code>, <code>groupEnd</code>, <code>time</code>, <code>timeEnd</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5514">#&#8203;5514</a>)</li>
<li><code>[docs]</code> Add documentation for interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5291">#&#8203;5291</a>)</li>
<li><code>[jest-editor-support]</code> Add watchAll flag (<a href="https://renovatebot.com/gh/facebook/jest/pull/5523">#&#8203;5523</a>)</li>
<li><code>[jest-cli]</code> Support multiple glob patterns for <code>collectCoverageFrom</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5537">#&#8203;5537</a>)</li>
<li><code>[docs]</code> Add versioned documentation to the website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5541">#&#8203;5541</a>)</li>
</ul>
<h5 id="chore--maintenance-7">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-config]</code> Allow <code>&lt;rootDir&gt;</code> to be used with <code>collectCoverageFrom</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5524">#&#8203;5524</a>)</li>
<li><code>[filenames]</code> Standardize files names in "integration-tests" folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5513">#&#8203;5513</a>)</li>
</ul>
<hr />
<h3 id="v2222httpsgithubcomfacebookjestblobmasterchangelogmdjest-2222"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2222"><code>v22.2.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/87cd2ffdd5bd7c8bf0b97dfd7adf22f29f1ca919…786f2956b863095313a8d727b1c85196542d1d1d">Compare Source</a></p>
<h5 id="fixes-12">Fixes</h5>
<ul>
<li><code>[babel-jest]</code> Revert "Remove retainLines from babel-jest" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5496">#&#8203;5496</a>)</li>
<li><code>[jest-docblock]</code> Support multiple of the same <code>@pragma</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5502">#&#8203;5154</a>)</li>
</ul>
<h5 id="features-9">Features</h5>
<ul>
<li><code>[jest-worker]</code> Assign a unique id for each worker and pass it to the child process. It will be available via <code>process.env.JEST_WORKER_ID</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5494">#&#8203;5494</a>)</li>
</ul>
<h5 id="chore--maintenance-8">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize file names in root (<a href="https://renovatebot.com/gh/facebook/jest/pull/5500">#&#8203;5500</a>)</li>
</ul>
<hr />
<h3 id="v2221httpsgithubcomfacebookjestblobmasterchangelogmdjest-2221"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2221"><code>v22.2.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/3b78f3c63a2f6923d8c17af8c54969870a744ffd…87cd2ffdd5bd7c8bf0b97dfd7adf22f29f1ca919">Compare Source</a></p>
<h5 id="fixes-13">Fixes</h5>
<ul>
<li><code>[jest-config]</code> "all" takes precedence over "lastCommit" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5486">#&#8203;5486</a>)</li>
</ul>
<hr />
<h3 id="v2220httpsgithubcomfacebookjestblobmasterchangelogmdjest-2220"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2220"><code>v22.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/7f715c88816dffe46463c46d7a9a45b6cb12348d…3b78f3c63a2f6923d8c17af8c54969870a744ffd">Compare Source</a></p>
<h5 id="features-10">Features</h5>
<ul>
<li><code>[jest-runner]</code> Move test summary to after coverage report (<a href="https://renovatebot.com/gh/facebook/jest/pull/4512">#&#8203;4512</a>)</li>
<li><code>[jest-cli]</code> Added <code>--notifyMode</code> to specify when to be notified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5125">#&#8203;5125</a>)</li>
<li><code>[diff-sequences]</code> New package compares items in two sequences to find a <strong>longest common subsequence</strong>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5407">#&#8203;5407</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>comment</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5437">#&#8203;5437</a>)</li>
<li><code>[jest-config]</code> Allow lastComit and changedFilesWithAncestor via JSON config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5476">#&#8203;5476</a>)</li>
<li><code>[jest-util]</code> Add deletion to <code>process.env</code> as well (<a href="https://renovatebot.com/gh/facebook/jest/pull/5466">#&#8203;5466</a>)</li>
<li><code>[jest-util]</code> Add case-insensitive getters/setters to <code>process.env</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5465">#&#8203;5465</a>)</li>
<li><code>[jest-mock]</code> Add util methods to create async functions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5318">#&#8203;5318</a>)</li>
</ul>
<h5 id="fixes-14">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add trailing slash when checking root folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5464">#&#8203;5464</a>)</li>
<li><code>[jest-cli]</code> Hide interactive mode if there are no failed snapshot tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/5450">#&#8203;5450</a>)</li>
<li><code>[babel-jest]</code> Remove retainLines from babel-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/5439">#&#8203;5439</a>)</li>
<li><code>[jest-cli]</code> Glob patterns ignore non-<code>require</code>-able files (e.g. <code>README.md</code>) (<a href="https://renovatebot.com/gh/facebook/jest/issues/5199">#&#8203;5199</a>)</li>
<li><code>[jest-mock]</code> Add backticks support (``) to <code>mock</code> a certain package via the <code>__mocks__</code> folder. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5426">#&#8203;5426</a>)</li>
<li><code>[jest-message-util]</code> Prevent an <code>ENOENT</code> crash when the test file contained a malformed source-map. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5405">#&#8203;5405</a>).</li>
<li><code>[jest]</code> Add <code>import-local</code> to <code>jest</code> package. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5353">#&#8203;5353</a>)</li>
<li><code>[expect]</code> Support class instances in <code>.toHaveProperty()</code> and <code>.toMatchObject</code> matcher. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5367">#&#8203;5367</a>)</li>
<li><code>[jest-cli]</code> Fix npm update command for snapshot summary. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5376">#&#8203;5376</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5389/">5389</a>)</li>
<li><code>[expect]</code> Make <code>rejects</code> and <code>resolves</code> synchronously validate its argument. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5364">#&#8203;5364</a>)</li>
<li><code>[docs]</code> Add tutorial page for ES6 class mocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5383">#&#8203;5383</a>)</li>
<li><code>[jest-resolve]</code> Search required modules in node_modules and then in custom paths. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5403">#&#8203;5403</a>)</li>
<li><code>[jest-resolve]</code> Get builtin modules from node core. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5411">#&#8203;5411</a>)</li>
<li><code>[jest-resolve]</code> Detect and preserve absolute paths in <code>moduleDirectories</code>. Do not generate additional (invalid) paths by prepending each ancestor of <code>cwd</code> to the absolute path. Additionally, this fixes functionality in Windows OS. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5398">#&#8203;5398</a>)</li>
</ul>
<h5 id="chore--maintenance-9">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-util]</code> Implement watch plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5399">#&#8203;5399</a>)</li>
</ul>
<hr />
<h3 id="v2214httpsgithubcomfacebookjestblobmasterchangelogmdjest-2214"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2214"><code>v22.1.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/a33ffa1bb01912aa3ad0e43f07fe6dcf021009d5…7f715c88816dffe46463c46d7a9a45b6cb12348d">Compare Source</a></p>
<h5 id="fixes-15">Fixes</h5>
<ul>
<li><code>[jest-util]</code> Add "debug" method to "console" implementations (<a href="https://renovatebot.com/gh/facebook/jest/pull/5350">#&#8203;5350</a>)</li>
<li><code>[jest-resolve]</code> Add condition to avoid infinite loop when node module package main is ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5344">#&#8203;5344)</a></li>
</ul>
<h5 id="features-11">Features</h5>
<ul>
<li><code>[jest-cli]</code> <code>--changedSince</code>: allow selectively running tests for code changed since arbitrary revisions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5312">#&#8203;5312</a>)</li>
</ul>
<hr />
<h3 id="v2213httpsgithubcomfacebookjestblobmasterchangelogmdjest-2213"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2213"><code>v22.1.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/c8bb0a791f79cedad05fc69b9ac799a05e885b10…a33ffa1bb01912aa3ad0e43f07fe6dcf021009d5">Compare Source</a></p>
<h5 id="fixes-16">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Check if the file belongs to the checked project before adding it to the list, also checking that the file name is not explicitly blacklisted (<a href="https://renovatebot.com/gh/facebook/jest/pull/5341">#&#8203;5341</a>)</li>
<li><code>[jest-editor-support]</code> Add option to spawn command in shell (<a href="https://renovatebot.com/gh/facebook/jest/pull/5340">#&#8203;5340</a>)</li>
</ul>
<hr />
<h3 id="v2212httpsgithubcomfacebookjestblobmasterchangelogmdjest-2212"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2212"><code>v22.1.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/03cce3d8718ad8c548406e35c8aa9b84b209d0e9…c8bb0a791f79cedad05fc69b9ac799a05e885b10">Compare Source</a></p>
<h5 id="fixes-17">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Check if the file belongs to the checked project before adding it to the list (<a href="https://renovatebot.com/gh/facebook/jest/pull/5335">#&#8203;5335</a>)</li>
<li><code>[jest-cli]</code> Fix <code>EISDIR</code> when a directory is passed as an argument to <code>jest</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5317">#&#8203;5317</a>)</li>
<li><code>[jest-config]</code> Added restoreMocks config option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5327">#&#8203;5327</a>)</li>
</ul>
<hr />
<h3 id="v2211httpsgithubcomfacebookjestblobmasterchangelogmdjest-2211"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2211"><code>v22.1.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/a6fa7e3676cec512b64a784712c88049a6bb5c68…03cce3d8718ad8c548406e35c8aa9b84b209d0e9">Compare Source</a></p>
<h5 id="fixes-18">Fixes</h5>
<ul>
<li><code>[*]</code> Move from "process.exit" to "exit. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5313">#&#8203;5313</a>)</li>
</ul>
<hr />
<h3 id="v2210httpsgithubcomfacebookjestblobmasterchangelogmdjest-2210"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2210"><code>v22.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/4bcfe19b89b445bec793ba0a2ac815d117fa8098…a6fa7e3676cec512b64a784712c88049a6bb5c68">Compare Source</a></p>
<h5 id="features-12">Features</h5>
<ul>
<li><code>[jest-cli]</code> Make Jest exit without an error when no tests are found in the case of <code>--lastCommit</code>, <code>--findRelatedTests</code>, or <code>--onlyChanged</code> options having been passed to the CLI</li>
<li><code>[jest-cli]</code> Add interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/3831">#&#8203;3831</a>)</li>
</ul>
<h5 id="fixes-19">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Use <code>import-local</code> to support global Jest installations. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5304">#&#8203;5304</a>)</li>
<li><code>[jest-runner]</code> Fix memory leak in coverage reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5289">#&#8203;5289</a>)</li>
<li><code>[docs]</code> Update mention of the minimal version of node supported (<a href="https://renovatebot.com/gh/facebook/jest/issues/4947">#&#8203;4947</a>)</li>
<li><code>[jest-cli]</code> Fix missing newline in console message (<a href="https://renovatebot.com/gh/facebook/jest/pull/5308">#&#8203;5308</a>)</li>
<li><code>[jest-cli]</code> <code>--lastCommit</code> and <code>--changedFilesWithAncestor</code> now take effect even when <code>--onlyChanged</code> is not specified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5307">#&#8203;5307</a>)</li>
</ul>
<h5 id="chore--maintenance-10">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize folder names under <code>integration-tests/</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5298">#&#8203;5298</a>)</li>
</ul>
<hr />
<h3 id="v2206httpsgithubcomfacebookjestblobmasterchangelogmdjest-2206"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2206"><code>v22.0.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/e5b9339e23ae5d3e9713c8210d365a005de823e9…4bcfe19b89b445bec793ba0a2ac815d117fa8098">Compare Source</a></p>
<h5 id="fixes-20">Fixes</h5>
<ul>
<li><code>[jest-jasmine2]</code> Fix memory leak in snapshot reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5279">#&#8203;5279</a>)</li>
<li><code>[jest-config]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5269">#&#8203;5269</a>)</li>
<li><code>[docs]</code> Document caveat with mocks, Enzyme, snapshots and React 16 (<a href="https://renovatebot.com/gh/facebook/jest/issues/5258">#&#8203;5258</a>)</li>
</ul>
<hr />
<h3 id="v2205httpsgithubcomfacebookjestblobmasterchangelogmdjest-2205"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2205"><code>v22.0.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/043a8b26aa6bc46379d5b220fa39c76edb950881…e5b9339e23ae5d3e9713c8210d365a005de823e9">Compare Source</a></p>
<h5 id="fixes-21">Fixes</h5>
<ul>
<li><code>[jest-leak-detector]</code> Removed the reference to <code>weak</code>. Now, parent projects must install it by hand for the module to work.</li>
<li><code>[expect]</code> Fail test when the types of <code>stringContaining</code> and <code>stringMatching</code> matchers do not match. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5069">#&#8203;5069</a>)</li>
<li><code>[jest-cli]</code> Treat dumb terminals as noninteractive (<a href="https://renovatebot.com/gh/facebook/jest/pull/5237">#&#8203;5237</a>)</li>
<li><code>[jest-cli]</code> <code>jest --onlyChanged --changedFilesWithAncestor</code> now also works with git. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5189">#&#8203;5189</a>)</li>
<li><code>[jest-config]</code> fix unexpected condition to avoid infinite recursion in Windows platform. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5161">#&#8203;5161</a>)</li>
<li><code>[jest-config]</code> Escape parentheses and other glob characters in <code>rootDir</code> before interpolating with <code>testMatch</code>. (<a href="https://renovatebot.com/gh/facebook/jest/issues/4838">#&#8203;4838</a>)</li>
<li><code>[jest-regex-util]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5230">#&#8203;5230</a>)</li>
<li><code>[expect]</code> Do not override <code>Error</code> stack (with <code>Error.captureStackTrace</code>) for custom matchers. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5162">#&#8203;5162</a>)</li>
<li><code>[pretty-format]</code> Pretty format for DOMStringMap and NamedNodeMap (<a href="https://renovatebot.com/gh/facebook/jest/pull/5233">#&#8203;5233</a>)</li>
<li><code>[jest-cli]</code> Use a better console-clearing string on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5251">#&#8203;5251</a>)</li>
</ul>
<h5 id="features-13">Features</h5>
<ul>
<li><code>[jest-jasmine]</code> Allowed classes and functions as <code>describe</code> names. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5154">#&#8203;5154</a>)</li>
<li><code>[jest-jasmine2]</code> Support generator functions as specs. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5166">#&#8203;5166</a>)</li>
<li><code>[jest-jasmine2]</code> Allow <code>spyOn</code> with getters and setters. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5107">#&#8203;5107</a>)</li>
<li><code>[jest-config]</code> Allow configuration objects inside <code>projects</code> array (<a href="https://renovatebot.com/gh/facebook/jest/pull/5176">#&#8203;5176</a>)</li>
<li><code>[expect]</code> Add support to <code>.toHaveProperty</code> matcher to accept the keyPath argument as an array of properties/indices. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5220">#&#8203;5220</a>)</li>
<li><code>[docs]</code> Add documentation for .toHaveProperty matcher to accept the keyPath argument as an array of properties/indices. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5220">#&#8203;5220</a>)</li>
<li><code>[jest-runner]</code> test environments are now passed a new <code>options</code> parameter. Currently this only has the <code>console</code> which is the test console that Jest will expose to tests. (<a href="https://renovatebot.com/gh/facebook/jest/issues/5223">#&#8203;5223</a>)</li>
<li><code>[jest-environment-jsdom]</code> pass the <code>options.console</code> to a custom instance of <code>virtualConsole</code> so jsdom is using the same console as the test. (<a href="https://renovatebot.com/gh/facebook/jest/issues/5223">#&#8203;5223</a>)</li>
</ul>
<h5 id="chore--maintenance-11">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Describe the order of execution of describe and test blocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5217">#&#8203;5217</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5238">#&#8203;5238</a>)</li>
<li><code>[docs]</code> Add a note on <code>moduleNameMapper</code> ordering. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5249">#&#8203;5249</a>)</li>
</ul>
<hr />
<h3 id="v2204httpsgithubcomfacebookjestblobmasterchangelogmdjest-2204"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2204"><code>v22.0.4</code></a></h3>
<h5 id="fixes-22">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> New line before quitting watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5158">#&#8203;5158</a>)</li>
</ul>
<h5 id="features-14">Features</h5>
<ul>
<li><code>[babel-jest]</code> moduleFileExtensions not passed to babel transformer. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5110">#&#8203;5110</a>)</li>
</ul>
<h5 id="chore--maintenance-12">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5142">#&#8203;5142</a>)</li>
</ul>
<hr />
<h3 id="v2203httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/884321de5ed1c047975b232a4bcdb257f14be5a6…699ddcc95f285941759c2b02caf114b96f5d4560">Compare Source</a></p>
<h5 id="chore--maintenance-13">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2202httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.2</code></a></h3>
<p><a h