### PR TITLE
fix: add multibyte character handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "jest": "^21.2.1",
-    "jest-cli": "^21.2.1"
+    "jest-cli": "^21.2.1",
+    "text-encoding": "^0.6.4"
   },
   "dependencies": {
     "@dcos/copychars": "^0.1.2"

--- a/src/__tests__/read-test.js
+++ b/src/__tests__/read-test.js
@@ -18,6 +18,20 @@ describe("read", function() {
     ]);
   });
 
+  it("returns multiple records with utf8 chars", function() {
+    expect(read("6\n1234ß4\n12343\n123")).toEqual([
+      ["1234ß", "1234", "123"],
+      ""
+    ]);
+  });
+
+  it("returns multiple records with utf8 and emoji in many messages", function() {
+    expect(read("6\n1234ß5\nß23414\n🤷‍♂️.")).toEqual([
+      ["1234ß", "ß234", "🤷‍♂️."],
+      ""
+    ]);
+  });
+
   it("returns partial records", function() {
     expect(read("5\n1234")).toEqual([[], "5\n1234"]);
   });

--- a/src/read.js
+++ b/src/read.js
@@ -1,10 +1,63 @@
 "use strict";
 
+const { TextDecoder, TextEncoder } = require("text-encoding");
+
 var copychars = require("@dcos/copychars").default;
 
 var RECORD_PATTERN = /^\d+\n.+/;
 
-module.exports = function read(input) {
+/**
+ *
+ * @param {Uint8Array} byteArray byteArray to parse
+ * @param {Uint8Array[]} records aray containing complete records
+ * @returns {Uint8Array} incomplete record data, if existent
+ */
+function parseRecordsWithRest(byteArray, records) {
+  if (byteArray.length === 0) {
+    return new Uint8Array();
+  }
+  const newlineCharCode = 10;
+  const zeroCharCode = 48;
+
+  const newlineIndex = byteArray.findIndex(
+    charCode => charCode == newlineCharCode
+  );
+
+  const recordSize = byteArray
+    .slice(0, newlineIndex)
+    .reduce((acc, val, index, array) => {
+      return (
+        acc + (val - zeroCharCode) * Math.pow(10, array.length - 1 - index)
+      );
+    }, 0);
+
+  if (byteArray.length <= newlineIndex + recordSize) {
+    return byteArray;
+  }
+
+  const record = byteArray.slice(
+    newlineIndex + 1,
+    newlineIndex + recordSize + 1
+  );
+  records.push(record);
+
+  return parseRecordsWithRest(
+    byteArray.slice(newlineIndex + recordSize + 1),
+    records
+  );
+}
+
+function read_multibyte(input) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder("utf-8");
+  const byteArray = encoder.encode(input);
+  const records = [];
+  const rest = parseRecordsWithRest(byteArray, records);
+
+  return [records.map(record => decoder.decode(record)), decoder.decode(rest)];
+}
+
+function read_ascii(input) {
   var records = [];
   var rest = input;
   var delimiterPosition,
@@ -32,4 +85,13 @@ module.exports = function read(input) {
   }
 
   return [records, rest];
+}
+
+module.exports = function read(input) {
+  for (var i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) > 127) {
+      return read_multibyte(input);
+    }
+  }
+  return read_ascii(input);
 };


### PR DESCRIPTION
RecordIO defines its record length in _bytes_, but JavaScript Strings are working with _characters_, this mismatch ead to broken records when they included multibyte chars.

Our fix enables multibyte handling, but _drastically_ reduces performance - we check the input for multibyte chars and only switch to the slow solution if necessary