### PR TITLE
fix: adjust parsing to handle UFT-8 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,24 @@ For example, a stream may look like:
 ```
 
 Further documentation can be found in the [Apache Mesos documentation](http://mesos.apache.org/documentation/latest/scheduler-http-api/#recordio-response-format).
+
+## Testing
+
+The implementation is tested with different UTF-8 character sets to verify that it reads the correct number of bytes from the input string.
+
+You can use the following python snippet to create test records from the provided messages array.
+
+```python
+messages = [u"foo", u"bar"]
+
+for message in messages:
+    chars = len(message)
+    size = len(message.encode("utf-8"))
+    print("Message")
+    print("> Chars: %s" % chars)
+    print("> Size: %s" % size)
+    print("> Message: %s" % message)
+    print("> Record: %s\\n%s" % (size, message))
+```
+
+Some of the tests use character sets from the [UTF-8 decoder capability and stress test](https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt) developed by [Markus Kuhn](http://www.cl.cam.ac.uk/~mgk25/) to ensure that parsing of character with different byte sequences works properly.

--- a/src/__tests__/read-test.js
+++ b/src/__tests__/read-test.js
@@ -18,6 +18,86 @@ describe("read", function() {
     ]);
   });
 
+  it("returns multiple records with utf8 characters", function() {
+    expect(read("6\n1234ß4\n12343\n123")).toEqual([
+      ["1234ß", "1234", "123"],
+      ""
+    ]);
+  });
+
+  it("reads multiple records with chinese characters", function() {
+    expect(read("12\n電風魚愛12\n马头书黄")).toEqual([
+      ["電風魚愛", "马头书黄"],
+      ""
+    ]);
+  });
+
+  it("reads records with japanese characters", function() {
+    expect(
+      read(
+        "6\n海社24\n勉暑漢神福練者都18\n器殺祝節梅類3\n祖27\n勤穀視署層著諸難朗"
+      )
+    ).toEqual([
+      ["海社", "勉暑漢神福練者都", "器殺祝節梅類", "祖", "勤穀視署層著諸難朗"],
+      ""
+    ]);
+  });
+
+  it("reads records with japanese characters", function() {
+    expect(read("7\nStraße6\nöfter7\nGefühl9\nÄnderung")).toEqual([
+      ["Straße", "öfter", "Gefühl", "Änderung"],
+      ""
+    ]);
+  });
+
+  it("returns multiple records with BMP and non BMP characters", function() {
+    expect(read("6\n1234ß6\nß432114\n🤷‍♂️.")).toEqual([
+      ["1234ß", "ß4321", "🤷‍♂️."],
+      ""
+    ]);
+  });
+
+  it("reads multiple records with non BMP characters", function() {
+    expect(read("25\n–±μβα°𝕆𝒾𝌆21\n😂📚🙆‍♀️")).toEqual([
+      ["–±μβα°𝕆𝒾𝌆", "😂📚🙆‍♀️"],
+      ""
+    ]);
+  });
+
+  it("reads multiple records with continuation byte character sequences", function() {
+    expect(
+      read(
+        "32\nÄÅÇÉÑÖÜáàâäãåçéè32\nêëíìîïñóòôöõúùûü36\n†°¢£§•¶ß®©™´¨≠ÆØ39\n∞±≤≥¥µ∂∑∏π∫ªºΩæø"
+      )
+    ).toEqual([
+      [
+        "ÄÅÇÉÑÖÜáàâäãåçéè",
+        "êëíìîïñóòôöõúùûü",
+        "†°¢£§•¶ß®©™´¨≠ÆØ",
+        "∞±≤≥¥µ∂∑∏π∫ªºΩæø"
+      ],
+      ""
+    ]);
+  });
+
+  it("reads multiple records with different byte sequences character", function() {
+    expect(
+      read(
+        "6\n¸ ˝ 12\n¯ ˘ ˙ ˚ 25\n Ò Ú Û Ù ı ˆ ˜ 52\n‡ · ‚ „ ‰ Â Ê Á Ë È Í Î Ï Ì Ó Ô 61\n– — “ ” ‘ ’ ÷ ◊ ÿ Ÿ ⁄ € ‹ › ﬁ ﬂ 49\n¿ ¡ ¬ √ ƒ ≈ ∆ « » … À Ã Õ Œ œ "
+      )
+    ).toEqual([
+      [
+        "¸ ˝ ",
+        "¯ ˘ ˙ ˚ ",
+        " Ò Ú Û Ù ı ˆ ˜ ",
+        "‡ · ‚ „ ‰ Â Ê Á Ë È Í Î Ï Ì Ó Ô ",
+        "– — “ ” ‘ ’ ÷ ◊ ÿ Ÿ ⁄ € ‹ › ﬁ ﬂ ",
+        "¿ ¡ ¬ √ ƒ ≈ ∆ « » … À Ã Õ Œ œ "
+      ],
+      ""
+    ]);
+  });
+
   it("returns partial records", function() {
     expect(read("5\n1234")).toEqual([[], "5\n1234"]);
   });

--- a/src/read.js
+++ b/src/read.js
@@ -4,32 +4,68 @@ var copychars = require("@dcos/copychars").default;
 
 var RECORD_PATTERN = /^\d+\n.+/;
 
+function charSizeAt(string, index) {
+  var charCode = string.charCodeAt(index);
+
+  if (isNaN(charCode)) {
+    return 0;
+  }
+
+  if (0xdc00 <= charCode && charCode <= 0xdfff) {
+    return 1;
+  }
+
+  if (charCode >= 0x0080 && charCode <= 0x07ff) {
+    return 2;
+  }
+
+  if (charCode >= 0x0800 && charCode <= 0xffff) {
+    return 3;
+  }
+  return 1;
+}
+
 module.exports = function read(input) {
   var records = [];
-  var rest = input;
-  var delimiterPosition,
-    recordLength,
+  var data = input;
+  var dataLength,
+    delimiterPosition,
+    record,
+    recordSize,
     recordStartPosition,
     recordEndPosition,
-    record;
+    size;
 
-  while (RECORD_PATTERN.test(rest)) {
-    delimiterPosition = rest.indexOf("\n");
+  while (RECORD_PATTERN.test(data)) {
+    dataLength = data.length;
+    delimiterPosition = data.indexOf("\n");
 
-    recordLength = parseInt(rest.substring(0, delimiterPosition), 10);
+    recordSize = parseInt(data.substring(0, delimiterPosition), 10);
 
     recordStartPosition = delimiterPosition + 1;
-    recordEndPosition = recordStartPosition + recordLength;
+    recordEndPosition = recordStartPosition;
 
-    if (isNaN(recordLength) || rest.length < recordEndPosition) {
-      return [records, rest];
+    if (isNaN(recordSize) || recordStartPosition >= dataLength) {
+      return [records, data];
     }
 
-    record = copychars(rest, recordStartPosition, recordLength);
-    rest = rest.substring(recordEndPosition);
+    size = 0;
+    while (size < recordSize && recordEndPosition < dataLength) {
+      size += charSizeAt(data, recordEndPosition++);
+    }
 
+    if (size != recordSize) {
+      return [records, data];
+    }
+
+    record = copychars(
+      data,
+      recordStartPosition,
+      recordEndPosition - recordStartPosition
+    );
+    data = data.substring(recordEndPosition);
     records.push(record);
   }
 
-  return [records, rest];
+  return [records, data];
 };


### PR DESCRIPTION
Correct the read implementation to count bytes instead of characters as required by the RecordIO spec to resolve issues with broken records that included multibyte characters (e.g. ß).

This fix introduces a helper to get the character byte size at a certain index. It's implemented following  https://en.wikipedia.org/wiki/UTF-8#Description and respects surrogate characters. For details on JavaScript string handling please refer to the following resources:

* https://mathiasbynens.be/notes/javascript-encoding
* http://unicode.org/versions/Unicode3.0.0/ch03.pdf
* https://github.com/koichik/node-codepoint/
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt

The implementation loops through the input data until the accumulated size matchs the recored size to find the recored end position. Looping through the string and calculating the respective size is significantly more performant than using regular expression to calculate the size or converting the string to a byte array and then back after reading the records.

Closes DCOS_OSS-3956